### PR TITLE
Preserve CJEU full-text translation languages

### DIFF
--- a/airflow/dags/data_loading/case_text_loader.py
+++ b/airflow/dags/data_loading/case_text_loader.py
@@ -48,13 +48,20 @@ def load_fulltext(client, files_location_paths: list) -> None:
                     continue
                 client.upsert_case_text(
                     case_id=case_id,
-                    language=(item.get("language") or "en").lower(),
+                    # cellar-extractor 2.x emits one record per available
+                    # translation and names the field ``text_language``.
+                    # Keep accepting the legacy ``language`` key for older
+                    # artifacts, but do not collapse every translation onto
+                    # the English conflict key.
+                    language=(item.get("text_language") or item.get("language") or "en").lower(),
                     source="CELLAR_ITEM",
                     fulltext=item.get("full_text") or item.get("text"),
                 )
                 loaded += 1
 
-        logging.info(f"{loaded}/{len(data)} full-text records loaded from {os.path.basename(file_location_path)}")
+        logging.info(
+            f"{loaded}/{len(data)} full-text records loaded from {os.path.basename(file_location_path)}"
+        )
         # another task may have consumed the file concurrently; upserts are
         # idempotent, so a double-read is harmless and a missing file is fine
         with suppress(FileNotFoundError):

--- a/airflow/dags/tests/test_case_text_loader.py
+++ b/airflow/dags/tests/test_case_text_loader.py
@@ -1,0 +1,53 @@
+import json
+import os
+
+from data_loading.case_text_loader import load_fulltext
+from definitions.storage_handler import JSON_FULL_TEXT_CELLAR
+
+
+class RecordingClient:
+    def __init__(self):
+        self.rows = []
+
+    def resolve_case_id(self, *, celex_id):
+        assert celex_id == "62026CJ0001"
+        return 42
+
+    def upsert_case_text(self, **row):
+        self.rows.append(row)
+
+
+def test_cellar_fulltexts_keep_each_translation_language(tmp_path):
+    path = tmp_path / os.path.basename(JSON_FULL_TEXT_CELLAR)
+    path.write_text(
+        json.dumps(
+            [
+                {"celex": "62026CJ0001", "text_language": "EN", "text": "English"},
+                {"celex": "62026CJ0001", "text_language": "FR", "text": "Français"},
+                {"celex": "62026CJ0001", "text_language": "NL", "text": "Nederlands"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    client = RecordingClient()
+
+    load_fulltext(client, [str(path)])
+
+    assert [row["language"] for row in client.rows] == ["en", "fr", "nl"]
+    assert [row["fulltext"] for row in client.rows] == ["English", "Français", "Nederlands"]
+    assert all(row["case_id"] == 42 for row in client.rows)
+    assert all(row["source"] == "CELLAR_ITEM" for row in client.rows)
+    assert not path.exists()
+
+
+def test_cellar_fulltext_accepts_legacy_language_key(tmp_path):
+    path = tmp_path / os.path.basename(JSON_FULL_TEXT_CELLAR)
+    path.write_text(
+        json.dumps([{"celex": "62026CJ0001", "language": "DE", "full_text": "Deutsch"}]),
+        encoding="utf-8",
+    )
+    client = RecordingClient()
+
+    load_fulltext(client, [str(path)])
+
+    assert client.rows[0]["language"] == "de"


### PR DESCRIPTION
## Summary
- load CELLAR 2.x `text_language` values instead of collapsing translations onto `en`
- retain compatibility with legacy `language` artifacts
- add multilingual loader regression tests

## Validation
- `python3 -m pytest -q airflow/dags/tests/test_case_text_loader.py airflow/dags/tests/test_row_processors.py airflow/dags/tests/test_postgres_client.py` (32 passed)