### PR TITLE
Preserve all EU case documents in monthly ETL

### DIFF
--- a/airflow/dags/data_extraction/caselaw/cellar/cellar_extraction.py
+++ b/airflow/dags/data_extraction/caselaw/cellar/cellar_extraction.py
@@ -69,9 +69,15 @@ def cellar_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
     os.environ["CURL_CA_BUNDLE"] = ""
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--amount", help="number of documents to retrieve", type=int, required=False)
-    parser.add_argument("--starting-date", help="Last modification date to look forward from", required=False)
-    parser.add_argument("--ending-date", help="Last modification date to look forward from", required=False)
+    parser.add_argument(
+        "--amount", help="number of documents to retrieve", type=int, required=False
+    )
+    parser.add_argument(
+        "--starting-date", help="Last modification date to look forward from", required=False
+    )
+    parser.add_argument(
+        "--ending-date", help="Last modification date to look forward from", required=False
+    )
     # Airflow gives extra arguments ('celery worker'); ignore unknown args.
     args, unknown = parser.parse_known_args(args)
 
@@ -155,8 +161,10 @@ def cellar_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
     end = time.time()
     logging.info("--- DONE ---")
     logging.info(f"Time taken: {time.strftime('%H:%M:%S', time.gmtime(end - start))}")
-    # Start date for the next incremental download
-    Variable.set(key="CELEX_LAST_DATE", value=args.ending_date)
+    # Explicitly dated monthly tasks must not race over the shared incremental
+    # checkpoint. Only the incremental mode owns and advances it.
+    if not args.starting_date:
+        Variable.set(key="CELEX_LAST_DATE", value=args.ending_date)
     return paths
 
 

--- a/airflow/dags/data_extraction/caselaw/echr/echr_extraction.py
+++ b/airflow/dags/data_extraction/caselaw/echr/echr_extraction.py
@@ -123,12 +123,17 @@ def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
         # legacy global-path mode: refuse to clobber an existing extraction
         Storage().setup_pipeline(output_paths=[paths["metadata"]])
 
-    try:
-        # Getting date of last update from airflow database
-        last_updated = Variable.get("ECHR_LAST_DATE")
-    except Exception:
-        last_updated = getenv("ECHR_START_DATE")
-        Variable.set(key="ECHR_LAST_DATE", value=last_updated)
+    # Explicitly dated monthly tasks do not need the shared incremental
+    # checkpoint. Avoiding it also prevents parallel July/August tasks from
+    # racing to create the same Airflow Variable.
+    last_updated = args.start_date
+    if not last_updated:
+        try:
+            # Getting date of last update from airflow database
+            last_updated = Variable.get("ECHR_LAST_DATE")
+        except Exception:
+            last_updated = getenv("ECHR_START_DATE")
+            Variable.set(key="ECHR_LAST_DATE", value=last_updated)
 
     today_date = str(datetime.today().date())
     logging.info("START DATE (LAST UPDATE):" + last_updated)
@@ -192,7 +197,8 @@ def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
     end = time.time()
     logging.info("--- DONE ---")
     logging.info(f"Time taken: {time.strftime('%H:%M:%S', time.gmtime(end - start))}")
-    Variable.set(key="ECHR_LAST_DATE", value=args.end_date or today_date)
+    if not args.start_date:
+        Variable.set(key="ECHR_LAST_DATE", value=args.end_date or today_date)
     return paths
 
 

--- a/airflow/dags/helpers/csv_manipulator.py
+++ b/airflow/dags/helpers/csv_manipulator.py
@@ -21,10 +21,6 @@ from definitions.storage_handler import DIR_DATA_PROCESSED
 # dropped here so the intermediate CSV stays the width of what we store.
 COLUMNS_TO_KEEP = set(MAP_CELLAR)
 
-# Judgments and AG opinions. "Unknown" is kept because the extractor leaves the
-# type blank for a share of rows that are judgments in practice.
-types_to_keep = ["Unknown", "Opinion of the Advocate General", "Judgment"]
-
 
 def drop_columns(data):
     """Reduce an extractor frame in place to CJEU case law and stored columns.
@@ -34,20 +30,16 @@ def drop_columns(data):
     for column in [c for c in data.columns if c not in COLUMNS_TO_KEEP]:
         data.pop(column)
 
-    # Court of Justice proper. The extractor returns everything carrying an
-    # ECLI, including national and EFTA courts.
-    data.drop(data[~data["ecli"].str.contains("ECLI:EU:C", na=False)].index, inplace=True)
+    # Keep every document from the EU courts (Court of Justice, General Court,
+    # and any other EU-court designator), while excluding national/EFTA ECLIs.
+    # Sector 6 below already identifies case-law documents, so filtering again
+    # by resource_type would silently discard Orders and other valid case data.
+    data.drop(data[~data["ecli"].str.startswith("ECLI:EU:", na=False)].index, inplace=True)
 
     # Sector 6 is case law. Note this also discards the sector 3 legislation
     # that cellar-extractor 2.x added support for: if that is wanted in
     # cle_v2, this is the line that decides it.
     data.drop(data[~data["celex"].str.startswith("6", na=False)].index, inplace=True)
-
-    data["resource_type"] = data["resource_type"].fillna("Unknown")
-    data.drop(
-        data[~data["resource_type"].str.contains("|".join(types_to_keep), na=False)].index,
-        inplace=True,
-    )
 
     data.reset_index(inplace=True, drop=True)
 

--- a/airflow/dags/tests/test_csv_manipulator.py
+++ b/airflow/dags/tests/test_csv_manipulator.py
@@ -1,0 +1,42 @@
+import pandas as pd
+
+from helpers.csv_manipulator import drop_columns
+
+
+def test_drop_columns_keeps_all_eu_sector_6_case_documents():
+    data = pd.DataFrame(
+        [
+            {
+                "ecli": "ECLI:EU:C:2026:1",
+                "celex": "62026CJ0001",
+                "resource_type": "Judgment",
+                "unused": "drop me",
+            },
+            {
+                "ecli": "ECLI:EU:T:2026:2",
+                "celex": "62026TO0002",
+                "resource_type": "Order",
+                "unused": "drop me",
+            },
+            {
+                "ecli": "ECLI:EFTA:2026:3",
+                "celex": "62026XX0003",
+                "resource_type": "Judgment",
+                "unused": "drop me",
+            },
+            {
+                "ecli": "ECLI:EU:C:2026:4",
+                "celex": "32026R0004",
+                "resource_type": "Regulation",
+                "unused": "drop me",
+            },
+        ]
+    )
+
+    drop_columns(data)
+
+    assert data[["ecli", "resource_type"]].to_dict("records") == [
+        {"ecli": "ECLI:EU:C:2026:1", "resource_type": "Judgment"},
+        {"ecli": "ECLI:EU:T:2026:2", "resource_type": "Order"},
+    ]
+    assert "unused" not in data.columns


### PR DESCRIPTION
## Summary
- retain every sector-6 `ECLI:EU:*` document, including General Court cases and Orders
- stop explicitly dated CELLAR/HUDOC month tasks racing over incremental Airflow checkpoints
- add regression coverage for Court of Justice, General Court, non-EU and non-case inputs

## Live evidence
The July/August 2026 run found 131 EU records, but the old filters discarded all 60 General Court records and all Orders; August therefore loaded 0/8 cases and 0/36 translations. Parallel HUDOC tasks also raced to create `ECHR_LAST_DATE`.

## Validation
- focused loader/processor/client suite: 33 passed