### PR TITLE
Normalize HUDOC language codes for Postgres

### DIFF
--- a/airflow/dags/data_loading/case_text_loader.py
+++ b/airflow/dags/data_loading/case_text_loader.py
@@ -12,6 +12,7 @@ import logging
 import os
 from contextlib import suppress
 
+from data_loading.language_codes import normalize_language_code
 from definitions.storage_handler import JSON_FULL_TEXT_CELLAR, JSON_FULL_TEXT_ECHR
 
 
@@ -35,7 +36,7 @@ def load_fulltext(client, files_location_paths: list) -> None:
                     continue
                 client.upsert_case_text(
                     case_id=case_id,
-                    language=(item.get("language") or "en").lower(),
+                    language=normalize_language_code(item.get("language")),
                     source="HUDOC",
                     fulltext=item.get("full_text") or item.get("text"),
                 )
@@ -53,7 +54,9 @@ def load_fulltext(client, files_location_paths: list) -> None:
                     # Keep accepting the legacy ``language`` key for older
                     # artifacts, but do not collapse every translation onto
                     # the English conflict key.
-                    language=(item.get("text_language") or item.get("language") or "en").lower(),
+                    language=normalize_language_code(
+                        item.get("text_language") or item.get("language")
+                    ),
                     source="CELLAR_ITEM",
                     fulltext=item.get("full_text") or item.get("text"),
                 )

--- a/airflow/dags/data_loading/language_codes.py
+++ b/airflow/dags/data_loading/language_codes.py
@@ -1,0 +1,12 @@
+"""Language-code normalization at source boundaries."""
+
+ISO3_TO_ISO2 = {
+    "eng": "en",
+    "fre": "fr",  # ISO 639-2/B spelling used by HUDOC
+    "fra": "fr",
+}
+
+
+def normalize_language_code(value, default="en"):
+    code = str(value or default).strip().lower()
+    return ISO3_TO_ISO2.get(code, code)

--- a/airflow/dags/data_loading/row_processors/postgres.py
+++ b/airflow/dags/data_loading/row_processors/postgres.py
@@ -1,5 +1,6 @@
 import logging
 
+from data_loading.language_codes import normalize_language_code
 from definitions.storage_handler import CSV_LOAD_FAILED, get_path_processed
 from definitions.terminology.attribute_names import (
     CELLAR_CELEX,
@@ -270,7 +271,11 @@ class PostgresRSProcessor(_BaseRowProcessor):
         bwb_id are populated in a way that lines up per-entry."""
         bwb_id = row.get(RS_BWB_ID) or None
         return [
-            {"raw_reference": legislation, "raw_resource": bwb_id, "source_dataset": "rs_lido_sqlite"}
+            {
+                "raw_reference": legislation,
+                "raw_resource": bwb_id,
+                "source_dataset": "rs_lido_sqlite",
+            }
             for legislation in (_split_set(row.get(RS_LEGISLATIONS)) or [])
         ]
 
@@ -324,7 +329,7 @@ class PostgresItemIdProcessor(_BaseRowProcessor):
         return {
             "item_id": row[ECHR_DOCUMENT_ID],
             "case_id": case_id,
-            "language": (row.get(ECHR_LANGUAGE) or "en").lower(),
+            "language": normalize_language_code(row.get(ECHR_LANGUAGE)),
             "extractedappno": row.get(ECHR_PARTICIPANTS),
             "docname": row.get(ECHR_TITLE),
             "doctype": row.get(ECHR_DOCUMENT_TYPE),

--- a/airflow/dags/tests/test_case_text_loader.py
+++ b/airflow/dags/tests/test_case_text_loader.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from data_loading.case_text_loader import load_fulltext
-from definitions.storage_handler import JSON_FULL_TEXT_CELLAR
+from definitions.storage_handler import JSON_FULL_TEXT_CELLAR, JSON_FULL_TEXT_ECHR
 
 
 class RecordingClient:
@@ -15,6 +15,10 @@ class RecordingClient:
 
     def upsert_case_text(self, **row):
         self.rows.append(row)
+
+    def resolve_case_id_by_item_id(self, item_id):
+        assert item_id == "001-12345"
+        return 43
 
 
 def test_cellar_fulltexts_keep_each_translation_language(tmp_path):
@@ -51,3 +55,18 @@ def test_cellar_fulltext_accepts_legacy_language_key(tmp_path):
     load_fulltext(client, [str(path)])
 
     assert client.rows[0]["language"] == "de"
+
+
+def test_hudoc_fulltext_normalizes_three_letter_language(tmp_path):
+    path = tmp_path / os.path.basename(JSON_FULL_TEXT_ECHR)
+    path.write_text(
+        json.dumps([{"item_id": "001-12345", "language": "FRE", "full_text": "Français"}]),
+        encoding="utf-8",
+    )
+    client = RecordingClient()
+
+    load_fulltext(client, [str(path)])
+
+    assert client.rows == [
+        {"case_id": 43, "language": "fr", "source": "HUDOC", "fulltext": "Français"}
+    ]

--- a/airflow/dags/tests/test_row_processors.py
+++ b/airflow/dags/tests/test_row_processors.py
@@ -10,6 +10,7 @@ from data_loading.row_processors.postgres import (
 from definitions.terminology.attribute_names import (
     CELLAR_CELEX,
     ECHR_DOCUMENT_ID,
+    ECHR_LANGUAGE,
     ECLI,
     RS_BWB_ID,
     RS_CITING,
@@ -56,7 +57,9 @@ def test_rs_processor_upload_row_commits_once_for_the_whole_row(client):
     assert len(conn.executed) == 3
 
 
-def test_rs_processor_upload_row_rolls_back_the_whole_row_on_mid_row_failure(client, redirect_failure_log):
+def test_rs_processor_upload_row_rolls_back_the_whole_row_on_mid_row_failure(
+    client, redirect_failure_log
+):
     processor = PostgresRSProcessor(path="unused", client=client)
     row = {ECLI: "ECLI:NL:HR:2024:2", RS_TITLE: "Some title"}
 
@@ -201,6 +204,23 @@ def test_item_id_processor_upload_row_commits_once(client):
     assert result == 1
     assert conn.commit_count == 1
     assert len(conn.executed) == 2
+
+
+def test_item_id_processor_normalizes_hudoc_language_to_iso2(client):
+    processor = PostgresItemIdProcessor(path="unused", client=client)
+
+    assert (
+        processor._detail_row({ECHR_DOCUMENT_ID: "001-12345", ECHR_LANGUAGE: "ENG"}, case_id=7)[
+            "language"
+        ]
+        == "en"
+    )
+    assert (
+        processor._detail_row({ECHR_DOCUMENT_ID: "001-12346", ECHR_LANGUAGE: "FRE"}, case_id=8)[
+            "language"
+        ]
+        == "fr"
+    )
 
 
 def test_item_id_processor_upload_row_rolls_back_on_failure(client, redirect_failure_log):


### PR DESCRIPTION
## Summary
- normalize HUDOC `ENG`/`FRE`/`FRA` codes to schema-compatible `en`/`fr`
- apply the same normalization to metadata and full-text loading
- add row-processor and full-text regression coverage

## Live evidence
The August 2026 HUDOC task extracted 46 metadata rows but rolled all 46 back on `fk_echr_document_language` because `eng`/`fre` are not keys in `cle_v2.language`.

## Validation
- focused loader/processor/client suite: 35 passed