### PR TITLE
Normalize CJEU creation dates for Postgres

### DIFF
--- a/airflow/dags/data_loading/row_processors/postgres.py
+++ b/airflow/dags/data_loading/row_processors/postgres.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import date
 
 from data_loading.language_codes import normalize_language_code
 from definitions.storage_handler import CSV_LOAD_FAILED, get_path_processed
@@ -57,6 +58,17 @@ def _split_set(value):
     if not value:
         return None
     return [v for v in value.split(SET_SEP) if v]
+
+
+def _earliest_iso_date(value):
+    """Reduce a semicolon-separated timestamp list to one PostgreSQL date."""
+    dates = []
+    for item in str(value or "").split(";"):
+        try:
+            dates.append(date.fromisoformat(item.strip()[:10]))
+        except ValueError:
+            continue
+    return min(dates) if dates else None
 
 
 class _BaseRowProcessor:
@@ -303,7 +315,7 @@ class PostgresCelexProcessor(_BaseRowProcessor):
             "proc_type": row.get(CELLAR_TYPE_PROCEDURE),
             # best available proxy for date_lodged; CELLAR extraction doesn't
             # capture a distinct "lodged" date today
-            "date_lodged": row.get(CELLAR_CREATION_OF_WORK) or None,
+            "date_lodged": _earliest_iso_date(row.get(CELLAR_CREATION_OF_WORK)),
             "journal_refs": row.get(CELLAR_JOURNAL_ARTICLES),
             "citations_extra_info": row.get(CELLAR_CITATIONS_EXTRA_INFO),
         }

--- a/airflow/dags/tests/test_row_processors.py
+++ b/airflow/dags/tests/test_row_processors.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 from data_loading.clients import postgres as postgres_module
 from data_loading.clients.postgres import PostgresCLEClient
@@ -9,6 +11,7 @@ from data_loading.row_processors.postgres import (
 )
 from definitions.terminology.attribute_names import (
     CELLAR_CELEX,
+    CELLAR_CREATION_OF_WORK,
     ECHR_DOCUMENT_ID,
     ECHR_LANGUAGE,
     ECLI,
@@ -175,6 +178,21 @@ def test_celex_processor_upload_row_commits_once(client):
     assert result == 1
     assert conn.commit_count == 1
     assert len(conn.executed) == 2
+
+
+def test_celex_processor_reduces_creation_timestamps_to_earliest_date(client):
+    processor = PostgresCelexProcessor(path="unused", client=client)
+    detail = processor._detail_row(
+        {
+            CELLAR_CELEX: "62026CJ0001",
+            CELLAR_CREATION_OF_WORK: (
+                "2026-08-25T13:14:18.334+02:00;" "2026-07-03T15:32:35.648+02:00;" "not-a-date"
+            ),
+        },
+        case_id=7,
+    )
+
+    assert detail["date_lodged"] == date(2026, 7, 3)
 
 
 def test_celex_processor_upload_row_rolls_back_on_failure(client, redirect_failure_log):


### PR DESCRIPTION
## Summary
- reduce semicolon-separated CELLAR creation timestamps to the earliest valid date
- keep the existing `date_lodged` proxy compatible with the Postgres date column
- add regression coverage for multi-valued and invalid timestamps

## Live evidence
The July 2026 run rolled back 42/60 surviving CJEU rows because `date_lodged` received several timestamps joined by semicolons.

## Validation
- focused loader/processor/client suite: 36 passed