### PR TITLE
Bound Rechtspraak pagination on empty pages

### DIFF
--- a/airflow/dags/data_extraction/caselaw/rechtspraak/rechtspraak_extraction.py
+++ b/airflow/dags/data_extraction/caselaw/rechtspraak/rechtspraak_extraction.py
@@ -32,6 +32,58 @@ FULL_TEXT_MIN_LENGTH = 1000
 EXTRA_SQLITE_COLUMNS = ["legislations_cited", "bwb_id"]
 
 
+def _bounded_get_data_from_url(base_url, total_docs, start_date, end_date):
+    """Paginate Rechtspraak with a no-progress stop.
+
+    The upstream count can occasionally exceed the rows its feed actually
+    returns (observed as 1,037 vs 1,036). The dependency's paginator waits for
+    the advertised total forever in that case, requesting empty pages without
+    a termination condition.
+    """
+    all_results = []
+    from_index = 0
+    while len(all_results) < total_docs:
+        url = rex._build_api_url(
+            base_url,
+            rex.MAX_ECLIS_PER_PAGE,
+            from_index,
+            start_date,
+            end_date,
+        )
+        response = rex.requests.get(url, timeout=rex.API_REQUEST_TIMEOUT)
+        response.raise_for_status()
+        response.raw.decode_content = True
+        payload = rex.parse_xml_response(response.text)
+        entries = payload.get("feed", {}).get("entry", [])
+        if not isinstance(entries, list):
+            entries = [entries] if entries else []
+        if not entries:
+            logging.warning(
+                "Rechtspraak returned an empty page at offset %s after %s/%s rows; "
+                "stopping instead of retrying forever",
+                from_index,
+                len(all_results),
+                total_docs,
+            )
+            break
+        all_results.extend(entries)
+        logging.info("Retrieved %s cases (total: %s)", len(entries), len(all_results))
+        from_index += rex.MAX_ECLIS_PER_PAGE
+        if len(all_results) < total_docs:
+            rex.time.sleep(rex.SLEEP_BETWEEN_REQUESTS)
+    return all_results[:total_docs]
+
+
+def _get_rechtspraak_bounded(**kwargs):
+    """Run the dependency with this task's bounded paginator."""
+    original = rex.get_data_from_url
+    rex.get_data_from_url = _bounded_get_data_from_url
+    try:
+        return rex.get_rechtspraak(**kwargs)
+    finally:
+        rex.get_data_from_url = original
+
+
 def _daily_ranges(starting_date: str, ending_date: str):
     """Yield one-day API windows for every date in an inclusive range."""
     current_date = datetime.strptime(starting_date, "%Y-%m-%d")
@@ -179,7 +231,7 @@ def rechtspraak_extract(
     # Extract per day in the range
     for current_date, next_date in _daily_ranges(starting_date, ending_date):
         logging.info(f"Processing date range: {current_date.date()} - {next_date.date()}")
-        base_extraction = rex.get_rechtspraak(
+        base_extraction = _get_rechtspraak_bounded(
             max_ecli=amount, sd=str(current_date.date()), ed=str(next_date.date()), save_file="n"
         )
         base_extraction = _cap_base_extraction(base_extraction, amount)

--- a/airflow/dags/tests/test_rechtspraak_extraction.py
+++ b/airflow/dags/tests/test_rechtspraak_extraction.py
@@ -1,5 +1,7 @@
 from datetime import datetime
+from types import SimpleNamespace
 
+from data_extraction.caselaw.rechtspraak import rechtspraak_extraction as extraction
 from data_extraction.caselaw.rechtspraak.rechtspraak_extraction import _daily_ranges
 
 
@@ -16,3 +18,38 @@ def test_daily_ranges_handles_a_single_day():
     assert list(_daily_ranges("2026-08-28", "2026-08-28")) == [
         (datetime(2026, 8, 28), datetime(2026, 8, 29))
     ]
+
+
+def test_bounded_paginator_stops_when_upstream_count_is_one_too_high(monkeypatch):
+    pages = [
+        {"feed": {"entry": [{"id": "one"}, {"id": "two"}]}},
+        {"feed": {"entry": []}},
+    ]
+    calls = []
+
+    class Response:
+        raw = SimpleNamespace(decode_content=False)
+        text = "ignored"
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(extraction.rex, "MAX_ECLIS_PER_PAGE", 2)
+    monkeypatch.setattr(extraction.rex, "API_REQUEST_TIMEOUT", 1)
+    monkeypatch.setattr(extraction.rex, "SLEEP_BETWEEN_REQUESTS", 0)
+    monkeypatch.setattr(
+        extraction.rex,
+        "_build_api_url",
+        lambda base, rows, offset, start, end: str(offset),
+    )
+    monkeypatch.setattr(
+        extraction.rex.requests,
+        "get",
+        lambda url, timeout: calls.append(url) or Response(),
+    )
+    monkeypatch.setattr(extraction.rex, "parse_xml_response", lambda text: pages.pop(0))
+
+    rows = extraction._bounded_get_data_from_url("api", 3, "2026-08-19", "2026-08-20")
+
+    assert rows == [{"id": "one"}, {"id": "two"}]
+    assert calls == ["0", "2"]


### PR DESCRIPTION
## Summary
- use a no-progress guard around the existing Rechtspraak feed paginator
- stop cleanly when the advertised count exceeds the rows the API actually returns
- retain the requested cap and existing package behavior otherwise
- add regression coverage for a count that is one row too high

## Live evidence
For 2026-08-19 the API advertises 1,037 documents but returns 1,036; rechtspraak-extractor 1.6.0 then requests empty pages forever.

## Validation
- bounded pagination regression executed in the Airflow image
- focused adjacent suite: 36 passed