### PR TITLE
Serialize LIDO SQLite builds

### DIFF
--- a/airflow/dags/lido_sqlite_build.py
+++ b/airflow/dags/lido_sqlite_build.py
@@ -46,6 +46,7 @@ dag = DAG(
     start_date=datetime(2025, 1, 1),
     catchup=False,
     schedule="0 0 8 * *",  # monthly, 8th at midnight UTC
+    max_active_runs=1,  # lido.db is a single-writer SQLite artifact
 )
 
 


### PR DESCRIPTION
Set `max_active_runs=1` on the existing `lido_sqlite_build` DAG. The DAG writes one shared SQLite artifact, so a released scheduled run and a manual run must not parse/write `lido.db` concurrently. This prevents the `sqlite3.OperationalError: database is locked` failure observed during the live July/August ETL test. No DAG is added.