### PR TITLE
Resolve composite CELEX ids for CJEU full text

### DIFF
--- a/airflow/dags/data_loading/case_text_loader.py
+++ b/airflow/dags/data_loading/case_text_loader.py
@@ -13,6 +13,7 @@ import os
 from contextlib import suppress
 
 from data_loading.language_codes import normalize_language_code
+from data_transformation.utils import format_cellar_celex
 from definitions.storage_handler import JSON_FULL_TEXT_CELLAR, JSON_FULL_TEXT_ECHR
 
 
@@ -42,7 +43,11 @@ def load_fulltext(client, files_location_paths: list) -> None:
                 )
                 loaded += 1
             elif file_name == os.path.basename(JSON_FULL_TEXT_CELLAR):
-                celex = item["celex"]
+                # CELLAR may identify a document with multiple CELEX values
+                # (for example ``62025CJ0051;62025CJ0051_SUM``).  Metadata is
+                # normalized to the canonical, non-suffixed CELEX before the
+                # case row is stored, so resolve full text by that same value.
+                celex = format_cellar_celex(item["celex"])
                 case_id = client.resolve_case_id(celex_id=celex)
                 if case_id is None:
                     logging.info(f"No case found for celex {celex}, skipping full text")

--- a/airflow/dags/tests/test_case_text_loader.py
+++ b/airflow/dags/tests/test_case_text_loader.py
@@ -57,6 +57,34 @@ def test_cellar_fulltext_accepts_legacy_language_key(tmp_path):
     assert client.rows[0]["language"] == "de"
 
 
+def test_cellar_fulltext_resolves_composite_celex_by_canonical_id(tmp_path):
+    path = tmp_path / os.path.basename(JSON_FULL_TEXT_CELLAR)
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "celex": "62026CJ0001;62026CJ0001_RES",
+                    "text_language": "EN",
+                    "text": "English",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    client = RecordingClient()
+
+    load_fulltext(client, [str(path)])
+
+    assert client.rows == [
+        {
+            "case_id": 42,
+            "language": "en",
+            "source": "CELLAR_ITEM",
+            "fulltext": "English",
+        }
+    ]
+
+
 def test_hudoc_fulltext_normalizes_three_letter_language(tmp_path):
     path = tmp_path / os.path.basename(JSON_FULL_TEXT_ECHR)
     path.write_text(


### PR DESCRIPTION
## Summary
- normalize composite CELLAR CELEX identifiers before resolving case rows
- preserve every available translation document on the canonical case
- add a regression test for base/summary CELEX pairs

## Test
- python -m pytest airflow/dags/tests/test_case_text_loader.py airflow/dags/tests/test_postgres_client.py airflow/dags/tests/test_row_processors.py -q

Observed in the July 2026 live db-dev test: 123 case rows loaded, but composite CELEX documents could not resolve and only 881/1617 full-text records attached.