### PR TITLE
Parse HUDOC dates as day first

### DIFF
--- a/airflow/dags/data_transformation/utils.py
+++ b/airflow/dags/data_transformation/utils.py
@@ -70,7 +70,7 @@ def format_rs_date(text):
 # converts string representation of a date into datetime (YYYY-MM-DD)
 # from original ECHR date format DD-MM-YYYY
 def format_echr_date(text):
-    return dateutil.parser.parse(text).date()
+    return dateutil.parser.parse(text, dayfirst=True).date()
 
 
 def format_domains(text):

--- a/airflow/dags/tests/test_data_transformation_utils.py
+++ b/airflow/dags/tests/test_data_transformation_utils.py
@@ -1,4 +1,10 @@
-from data_transformation.utils import format_jurisdiction, format_rs_newline_list
+from datetime import date
+
+from data_transformation.utils import (
+    format_echr_date,
+    format_jurisdiction,
+    format_rs_newline_list,
+)
 
 
 def test_format_jurisdiction_accepts_lowercase_dcterms_language_code():
@@ -27,3 +33,7 @@ def test_format_rs_newline_list_single_value_no_trailing_separator():
 def test_format_rs_newline_list_returns_none_for_empty_input():
     assert format_rs_newline_list("") is None
     assert format_rs_newline_list("\n\n  \n") is None
+
+
+def test_format_echr_date_uses_documented_day_month_year_order():
+    assert format_echr_date("09-07-2026") == date(2026, 7, 9)


### PR DESCRIPTION
## Summary
- parse documented HUDOC DD-MM-YYYY dates with day-first semantics
- add a regression test for an ambiguous July date

## Test
- python -m pytest airflow/dags/tests/test_data_transformation_utils.py airflow/dags/tests/test_case_text_loader.py airflow/dags/tests/test_row_processors.py -q

Observed in the July/August 2026 db-dev run: 09-07-2026 was persisted as 2026-09-07.