### PR TITLE
Make HUDOC full-text extraction reliable

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -7,7 +7,9 @@
 
 # caselaw source extractors
 cellar_extractor==2.0.0
-echr_extractor==1.2.1
+# Pin the unreleased timeout propagation fix by immutable commit. HUDOC's
+# conversion endpoint routinely takes longer than the old hard-coded 10s.
+echr_extractor @ https://github.com/maastrichtlawtech/echr-extractor/archive/e86a7957410db2ae904bd7918319a586a2ecc227.tar.gz
 rechtspraak_extractor==1.6.0
 rechtspraak_citations_extractor==1.2.0
 rechtspraak-lido-sqlite==0.2.0


### PR DESCRIPTION
## Summary
- update only the `echr_extractor` dependency to an immutable fix commit
- keep the existing `echr_etl` DAG logic unchanged; no DAGs are added or replaced

The extractor now owns the HUDOC policy: at most four conversion workers, a 75-second request timeout, two attempts, and safe empty-input handling.

## Why
The July/August staging run loaded 162 HUDOC metadata variants but zero bodies. Direct checks against the official endpoint found 85 full HTML bodies, 77 legitimate `204 No Content` placeholder variants, and response times beyond the old hard-coded 10 seconds.

## Verification
- case-law-explorer DAG tests: 44 passed
- echr-extractor suite: 241 passed, 14 skipped
- live item `001-250884`: 20,610 parsed characters with the new extractor policy