### PR TITLE
Pin released HUDOC full-text reliability fix

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -9,7 +9,7 @@
 cellar_extractor==2.0.0
 # Pin the unreleased timeout propagation fix by immutable commit. HUDOC's
 # conversion endpoint routinely takes longer than the old hard-coded 10s.
-echr_extractor @ https://github.com/maastrichtlawtech/echr-extractor/archive/e86a7957410db2ae904bd7918319a586a2ecc227.tar.gz
+echr_extractor==1.3.2
 rechtspraak_extractor==1.6.0
 rechtspraak_citations_extractor==1.2.0
 rechtspraak-lido-sqlite==0.2.0

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -7,8 +7,8 @@
 
 # caselaw source extractors
 cellar_extractor==2.0.0
-# Pin the unreleased timeout propagation fix by immutable commit. HUDOC's
-# conversion endpoint routinely takes longer than the old hard-coded 10s.
+# Pin the timeout and worker-limit fix. HUDOC's conversion endpoint routinely
+# takes longer than the old hard-coded 10s.
 echr_extractor==1.3.2
 rechtspraak_extractor==1.6.0
 rechtspraak_citations_extractor==1.2.0


### PR DESCRIPTION
Pins `echr_extractor==1.3.2`, the released extractor version containing the 75-second full-text timeout and four-worker cap. No DAG code or new DAG is added.\n\nVerified in the existing local Airflow Docker image: the wheel installs without Git and imports `DEFAULT_TIMEOUT_SECONDS=75` and `DEFAULT_MAX_WORKERS=4`.