### PR TITLE
Resolve HUDOC citations in the existing ETL DAG

### DIFF
--- a/airflow/dags/cellar_etl.py
+++ b/airflow/dags/cellar_etl.py
@@ -6,7 +6,12 @@ from data_extraction.caselaw.cellar.cellar_extraction import cellar_extract
 from data_loading import data_loader
 from data_transformation import data_transformer
 from dotenv import find_dotenv, load_dotenv
-from etl_factory import DEFAULT_ARGS, build_monthly_task_group, cleanup_raw_files, get_var
+from etl_factory import (
+    DEFAULT_ARGS,
+    build_monthly_task_group,
+    cleanup_raw_files,
+    get_var,
+)
 
 from airflow import DAG
 
@@ -43,7 +48,9 @@ def cellar_etl(**kwargs):
         "--ending-date",
         end_date.strftime("%Y-%m-%d"),
     ]
-    raw_paths = cellar_extract(extraction_args, output_dir=month_dir, skip_if_exists=True)
+    raw_paths = cellar_extract(
+        extraction_args, output_dir=month_dir, skip_if_exists=True
+    )
     logging.info("Cellar extraction completed")
 
     # Transform into a month-scoped processed dir, then load exactly those
@@ -63,7 +70,14 @@ def cellar_etl(**kwargs):
         edge_dir=month_dir,
     )
 
-    cleanup_raw_files([raw_paths["metadata"], raw_paths["nodes"], raw_paths["edges"]])
+    cleanup_raw_files(
+        [
+            raw_paths["metadata"],
+            raw_paths["full_text"],
+            raw_paths["nodes"],
+            raw_paths["edges"],
+        ]
+    )
     logging.info("Cellar ETL completed successfully")
 
 

--- a/airflow/dags/data_extraction/caselaw/echr/echr_extraction.py
+++ b/airflow/dags/data_extraction/caselaw/echr/echr_extraction.py
@@ -13,6 +13,7 @@ from os import getenv
 from os.path import basename, join
 
 import echr_extractor as echr
+import pandas as pd
 from airflow.models.variable import Variable
 from definitions.storage_handler import (
     CSV_ECHR_CASES,
@@ -37,13 +38,38 @@ def _output_paths(output_dir):
             "full_text": join(output_dir, basename(JSON_FULL_TEXT_ECHR)),
             "nodes": join(output_dir, TXT_ECHR_NODES),
             "edges": join(output_dir, TXT_ECHR_EDGES),
+            "missing_references": join(output_dir, "ECHR_missing_references.csv"),
         }
     return {
         "metadata": get_path_raw(CSV_ECHR_CASES),
         "full_text": JSON_FULL_TEXT_ECHR,
         "nodes": get_path_raw(TXT_ECHR_NODES),
         "edges": get_path_raw(TXT_ECHR_EDGES),
+        "missing_references": get_path_raw("ECHR_missing_references.csv"),
     }
+
+
+def _resolve_external_citations_enabled():
+    return str(
+        Variable.get(
+            "ECHR_RESOLVE_EXTERNAL_CITATIONS",
+            default_var=getenv("ECHR_RESOLVE_EXTERNAL_CITATIONS", "true"),
+        )
+    ).lower() in ("true", "1", "yes")
+
+
+def _write_citation_artifacts(metadata, paths):
+    nodes, edges, missing = echr.get_nodes_edges(
+        df=metadata,
+        save_file="n",
+        resolve_external=_resolve_external_citations_enabled(),
+    )
+    nodes[["ecli"]].to_csv(paths["nodes"], index=False, header=False)
+    with open(paths["edges"], "w") as f:
+        for _, row in edges.iterrows():
+            for target in row["references"]:
+                f.write(f"{row['ecli']},{target}\n")
+    missing.to_csv(paths["missing_references"], index=False)
 
 
 def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
@@ -54,6 +80,11 @@ def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
     """
     paths = _output_paths(output_dir)
     if skip_if_exists and os.path.exists(paths["metadata"]):
+        if not all(
+            os.path.exists(paths[name]) for name in ("edges", "missing_references")
+        ):
+            logging.info("Rebuilding missing ECHR citation artifacts from metadata")
+            _write_citation_artifacts(pd.read_csv(paths["metadata"]), paths)
         logging.info(f"{paths['metadata']} exists, skipping extraction.")
         return paths
 
@@ -89,7 +120,10 @@ def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
         default=None,
     )
     parser.add_argument(
-        "--end-date", help="Last modification date to look back from", required=False, default=None
+        "--end-date",
+        help="Last modification date to look back from",
+        required=False,
+        default=None,
     )
     parser.add_argument(
         "--skip-missing-dates",
@@ -154,7 +188,9 @@ def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
         f"Downloading {args.count if 'count' in args and args.count is not None else 'all'} ECHR documents"
     )
     if args.fresh:
-        metadata, full_text = echr.get_echr_extra(**kwargs, start_date="1990-01-01", save_file="n")
+        metadata, full_text = echr.get_echr_extra(
+            **kwargs, start_date="1990-01-01", save_file="n"
+        )
     elif args.start_date and args.end_date:
         logging.info(
             f"Starting from manually specified date: {args.start_date} and ending at end date: {args.end_date}"
@@ -169,7 +205,9 @@ def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
         )
     elif args.end_date:
         logging.info(f"Ending at manually specified end date {args.end_date}")
-        metadata, full_text = echr.get_echr_extra(**kwargs, end_date=args.end_date, save_file="n")
+        metadata, full_text = echr.get_echr_extra(
+            **kwargs, end_date=args.end_date, save_file="n"
+        )
     else:
         logging.info("Starting from the last update the script can find")
         metadata, full_text = echr.get_echr_extra(
@@ -183,14 +221,9 @@ def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
             json.dump(full_text, f)
         logging.info("Adding Nodes and Edges lists to storage")
         # Getting nodes and edges, citation-based. For creating a citation graph
-        nodes, edges, _missing = echr.get_nodes_edges(df=metadata, save_file="n")
-        nodes[["ecli"]].to_csv(paths["nodes"], index=False, header=False)
-        # one "<source>,<target>" line per citation: the format the citation
-        # graph loader parses. edges rows are (ecli, [target eclis]).
-        with open(paths["edges"], "w") as f:
-            for _, row in edges.iterrows():
-                for target in row["references"]:
-                    f.write(f"{row['ecli']},{target}\n")
+        # One "<source>,<target>" line per citation: the format the citation
+        # graph loader parses. Missing references are retained for verification.
+        _write_citation_artifacts(metadata, paths)
     else:
         logging.info("No ECHR data found")
 

--- a/airflow/dags/data_loading/case_text_loader.py
+++ b/airflow/dags/data_loading/case_text_loader.py
@@ -10,7 +10,6 @@ longer needed -- this reads the same JSON files and upserts each entry.
 import json
 import logging
 import os
-from contextlib import suppress
 
 from data_loading.language_codes import normalize_language_code
 from data_transformation.utils import format_cellar_celex
@@ -33,7 +32,9 @@ def load_fulltext(client, files_location_paths: list) -> None:
                 item_id = item["item_id"]
                 case_id = client.resolve_case_id_by_item_id(item_id)
                 if case_id is None:
-                    logging.info(f"No case found for ECHR item_id {item_id}, skipping full text")
+                    logging.info(
+                        f"No case found for ECHR item_id {item_id}, skipping full text"
+                    )
                     continue
                 client.upsert_case_text(
                     case_id=case_id,
@@ -70,10 +71,6 @@ def load_fulltext(client, files_location_paths: list) -> None:
         logging.info(
             f"{loaded}/{len(data)} full-text records loaded from {os.path.basename(file_location_path)}"
         )
-        # another task may have consumed the file concurrently; upserts are
-        # idempotent, so a double-read is harmless and a missing file is fine
-        with suppress(FileNotFoundError):
-            os.remove(file_location_path)
 
 
 if __name__ == "__main__":

--- a/airflow/dags/data_loading/citation_graph_loader.py
+++ b/airflow/dags/data_loading/citation_graph_loader.py
@@ -13,7 +13,6 @@ Edge file format (one per line): "<source_identifier>,<target_identifier>"
 
 import logging
 import os
-from contextlib import suppress
 
 from definitions.storage_handler import (
     TXT_CELLAR_EDGES,
@@ -22,7 +21,16 @@ from definitions.storage_handler import (
 )
 
 CELLAR_EDGE_FILES = [(TXT_CELLAR_EDGES, "celex", "EURLEX")]
-ECHR_EDGE_FILES = [(TXT_ECHR_EDGES, "ecli", "ECHR")]
+ECHR_EDGE_FILES = [(TXT_ECHR_EDGES, "echr", "ECHR")]
+
+
+def _resolve_case_id(client, identifier: str, target_key: str):
+    if target_key == "celex":
+        return client.resolve_case_id(celex_id=identifier)
+    case_id = client.resolve_case_id(ecli=identifier)
+    if case_id is None:
+        case_id = client.resolve_case_id_by_item_id(identifier)
+    return case_id
 
 
 def _load_edge_file(client, path: str, target_key: str, source_dataset: str) -> int:
@@ -38,34 +46,30 @@ def _load_edge_file(client, path: str, target_key: str, source_dataset: str) -> 
                 continue
             source_id, target_id = line.split(",", 1)
 
-            source_case_id = (
-                client.resolve_case_id(celex_id=source_id)
-                if target_key == "celex"
-                else client.resolve_case_id(ecli=source_id)
-            )
+            source_case_id = _resolve_case_id(client, source_id, target_key)
             if source_case_id is None:
                 continue
 
-            target_case_id = (
-                client.resolve_case_id(celex_id=target_id)
-                if target_key == "celex"
-                else client.resolve_case_id(ecli=target_id)
-            )
+            target_case_id = _resolve_case_id(client, target_id, target_key)
 
             client.upsert_citation(
                 source_case_id=source_case_id,
                 target_case_id=target_case_id,
-                target_celex_raw=target_id if target_key == "celex" and target_case_id is None else None,
-                target_ecli_raw=target_id if target_key == "ecli" and target_case_id is None else None,
+                target_celex_raw=(
+                    target_id
+                    if target_key == "celex" and target_case_id is None
+                    else None
+                ),
+                target_ecli_raw=(
+                    target_id
+                    if target_key == "echr" and target_case_id is None
+                    else None
+                ),
                 relation_type="cites",
                 source_dataset=source_dataset,
             )
             loaded += 1
 
-    # another task may have consumed the file concurrently; upserts are
-    # idempotent, so a double-read is harmless and a missing file is fine
-    with suppress(FileNotFoundError):
-        os.remove(path)
     return loaded
 
 

--- a/airflow/dags/echr_etl.py
+++ b/airflow/dags/echr_etl.py
@@ -6,7 +6,12 @@ from data_extraction.caselaw.echr.echr_extraction import echr_extract
 from data_loading import data_loader
 from data_transformation import data_transformer
 from dotenv import find_dotenv, load_dotenv
-from etl_factory import DEFAULT_ARGS, build_monthly_task_group, cleanup_raw_files, get_var
+from etl_factory import (
+    DEFAULT_ARGS,
+    build_monthly_task_group,
+    cleanup_raw_files,
+    get_var,
+)
 
 from airflow import DAG
 
@@ -63,7 +68,15 @@ def echr_etl(**kwargs):
         edge_dir=month_dir,
     )
 
-    cleanup_raw_files([raw_paths["metadata"], raw_paths["nodes"], raw_paths["edges"]])
+    cleanup_raw_files(
+        [
+            raw_paths["metadata"],
+            raw_paths["full_text"],
+            raw_paths["nodes"],
+            raw_paths["edges"],
+            raw_paths["missing_references"],
+        ]
+    )
     logging.info("ECHR ETL completed successfully")
 
 

--- a/airflow/dags/tests/test_case_text_loader.py
+++ b/airflow/dags/tests/test_case_text_loader.py
@@ -38,16 +38,22 @@ def test_cellar_fulltexts_keep_each_translation_language(tmp_path):
     load_fulltext(client, [str(path)])
 
     assert [row["language"] for row in client.rows] == ["en", "fr", "nl"]
-    assert [row["fulltext"] for row in client.rows] == ["English", "Français", "Nederlands"]
+    assert [row["fulltext"] for row in client.rows] == [
+        "English",
+        "Français",
+        "Nederlands",
+    ]
     assert all(row["case_id"] == 42 for row in client.rows)
     assert all(row["source"] == "CELLAR_ITEM" for row in client.rows)
-    assert not path.exists()
+    assert path.exists()
 
 
 def test_cellar_fulltext_accepts_legacy_language_key(tmp_path):
     path = tmp_path / os.path.basename(JSON_FULL_TEXT_CELLAR)
     path.write_text(
-        json.dumps([{"celex": "62026CJ0001", "language": "DE", "full_text": "Deutsch"}]),
+        json.dumps(
+            [{"celex": "62026CJ0001", "language": "DE", "full_text": "Deutsch"}]
+        ),
         encoding="utf-8",
     )
     client = RecordingClient()
@@ -88,7 +94,9 @@ def test_cellar_fulltext_resolves_composite_celex_by_canonical_id(tmp_path):
 def test_hudoc_fulltext_normalizes_three_letter_language(tmp_path):
     path = tmp_path / os.path.basename(JSON_FULL_TEXT_ECHR)
     path.write_text(
-        json.dumps([{"item_id": "001-12345", "language": "FRE", "full_text": "Français"}]),
+        json.dumps(
+            [{"item_id": "001-12345", "language": "FRE", "full_text": "Français"}]
+        ),
         encoding="utf-8",
     )
     client = RecordingClient()

--- a/airflow/dags/tests/test_citation_graph_loader.py
+++ b/airflow/dags/tests/test_citation_graph_loader.py
@@ -1,0 +1,51 @@
+from data_loading.citation_graph_loader import _load_edge_file
+
+
+class RecordingClient:
+    def __init__(self):
+        self.rows = []
+
+    def resolve_case_id(self, *, ecli=None, celex_id=None):
+        if celex_id:
+            return {"62026CJ0001": 30, "62025CJ0002": 31}.get(celex_id)
+        return {"ECLI:CE:ECHR:2026:SOURCE": 11, "ECLI:CE:ECHR:2025:TARGET": 20}.get(
+            ecli
+        )
+
+    def resolve_case_id_by_item_id(self, item_id):
+        return {"001-source": 10, "001-target": 21}.get(item_id)
+
+    def upsert_citation(self, **row):
+        self.rows.append(row)
+
+
+def test_echr_edges_resolve_ecli_and_item_id_identifiers(tmp_path):
+    path = tmp_path / "ECHR_edges.txt"
+    path.write_text(
+        "001-source,ECLI:CE:ECHR:2025:TARGET\n"
+        "ECLI:CE:ECHR:2026:SOURCE,001-target\n"
+        "001-source,001-unknown\n",
+        encoding="utf-8",
+    )
+    client = RecordingClient()
+
+    loaded = _load_edge_file(client, str(path), "echr", "ECHR")
+
+    assert loaded == 3
+    assert [row["source_case_id"] for row in client.rows] == [10, 11, 10]
+    assert [row["target_case_id"] for row in client.rows] == [20, 21, None]
+    assert client.rows[2]["target_ecli_raw"] == "001-unknown"
+    assert path.exists()
+
+
+def test_cellar_edges_still_resolve_celex(tmp_path):
+    path = tmp_path / "cellar_edges.txt"
+    path.write_text("62026CJ0001,62025CJ0002\n", encoding="utf-8")
+    client = RecordingClient()
+
+    loaded = _load_edge_file(client, str(path), "celex", "EURLEX")
+
+    assert loaded == 1
+    assert client.rows[0]["source_case_id"] == 30
+    assert client.rows[0]["target_case_id"] == 31
+    assert path.exists()


### PR DESCRIPTION
Keeps the existing echr_etl DAG and makes its citation step rely on the echr-extractor external resolver. It rebuilds missing citation artifacts from retained metadata, resolves ECHR identifiers by ECLI or HUDOC item ID, and retains full-text and edge artifacts unless ETL_CLEANUP_RAW is explicitly enabled. No new DAG and no production writer.

Verification:
- local: 46 tests passed, excluding the pre-existing unavailable rechtspraak_extractor collection
- existing Airflow Docker image with echr_extractor 1.3.2: 46 tests passed
- compileall and Black checks passed