### PR TITLE
Store HUDOC citation edges by canonical item ID

### DIFF
--- a/airflow/dags/data_extraction/caselaw/echr/echr_extraction.py
+++ b/airflow/dags/data_extraction/caselaw/echr/echr_extraction.py
@@ -58,6 +58,53 @@ def _resolve_external_citations_enabled():
     ).lower() in ("true", "1", "yes")
 
 
+def _canonical_item_ids(metadata):
+    """Map corpus ECLIs to one real HUDOC document item ID.
+
+    HUDOC language variants share an ECLI, while cle_v2 stores each item ID as
+    a separate case and keeps cases.ecli unique. Prefer the variant with an
+    extracted application number; placeholder variants do not have one.
+    """
+    required = {"ecli", "itemid"}
+    if not required.issubset(metadata.columns):
+        return {}
+    candidates = metadata.loc[:, ["ecli", "itemid"]].copy()
+    appnos = metadata.get("extractedappno")
+    candidates["has_appno"] = (
+        appnos.notna() & appnos.astype(str).str.strip().ne("")
+        if appnos is not None
+        else False
+    )
+    candidates["ecli"] = candidates["ecli"].astype(str).str.strip()
+    candidates["itemid"] = candidates["itemid"].astype(str).str.strip()
+    candidates = candidates[
+        candidates["ecli"].ne("")
+        & candidates["ecli"].str.lower().ne("nan")
+        & candidates["itemid"].ne("")
+        & candidates["itemid"].str.lower().ne("nan")
+    ]
+    candidates = candidates.sort_values("has_appno", ascending=False, kind="stable")
+    candidates = candidates.drop_duplicates("ecli")
+    return dict(zip(candidates["ecli"], candidates["itemid"]))
+
+
+def _normalize_edge_identifiers(metadata, path):
+    corpus_item_ids = _canonical_item_ids(metadata)
+    normalized_path = f"{path}.normalized"
+    with open(path, encoding="utf-8") as source_file, open(
+        normalized_path, "w", encoding="utf-8"
+    ) as target_file:
+        for line in source_file:
+            line = line.strip()
+            if not line or "," not in line:
+                continue
+            source, target = line.split(",", 1)
+            source = corpus_item_ids.get(source, source)
+            target = corpus_item_ids.get(target, target)
+            target_file.write(f"{source},{target}\n")
+    os.replace(normalized_path, path)
+
+
 def _write_citation_artifacts(metadata, paths):
     nodes, edges, missing = echr.get_nodes_edges(
         df=metadata,
@@ -65,10 +112,13 @@ def _write_citation_artifacts(metadata, paths):
         resolve_external=_resolve_external_citations_enabled(),
     )
     nodes[["ecli"]].to_csv(paths["nodes"], index=False, header=False)
+    corpus_item_ids = _canonical_item_ids(metadata)
     with open(paths["edges"], "w") as f:
         for _, row in edges.iterrows():
+            source = corpus_item_ids.get(str(row["ecli"]), row["ecli"])
             for target in row["references"]:
-                f.write(f"{row['ecli']},{target}\n")
+                target = corpus_item_ids.get(str(target), target)
+                f.write(f"{source},{target}\n")
     missing.to_csv(paths["missing_references"], index=False)
 
 
@@ -80,11 +130,14 @@ def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
     """
     paths = _output_paths(output_dir)
     if skip_if_exists and os.path.exists(paths["metadata"]):
+        metadata = pd.read_csv(paths["metadata"])
         if not all(
             os.path.exists(paths[name]) for name in ("edges", "missing_references")
         ):
             logging.info("Rebuilding missing ECHR citation artifacts from metadata")
-            _write_citation_artifacts(pd.read_csv(paths["metadata"]), paths)
+            _write_citation_artifacts(metadata, paths)
+        else:
+            _normalize_edge_identifiers(metadata, paths["edges"])
         logging.info(f"{paths['metadata']} exists, skipping extraction.")
         return paths
 

--- a/airflow/dags/tests/conftest.py
+++ b/airflow/dags/tests/conftest.py
@@ -25,9 +25,25 @@ def _stub_package(name):
 
 
 _stub_package("airflow")
+_stub_package("airflow.models")
 _stub_package("airflow.providers")
 _stub_package("airflow.providers.postgres")
 _stub_package("airflow.providers.postgres.hooks")
+
+if "airflow.models.variable" not in sys.modules:
+    variable_module = types.ModuleType("airflow.models.variable")
+
+    class Variable:
+        @staticmethod
+        def get(key, default_var=None):
+            return default_var
+
+        @staticmethod
+        def set(key, value):
+            return None
+
+    variable_module.Variable = Variable
+    sys.modules["airflow.models.variable"] = variable_module
 
 if "airflow.providers.postgres.hooks.postgres" not in sys.modules:
     hooks_postgres = types.ModuleType("airflow.providers.postgres.hooks.postgres")

--- a/airflow/dags/tests/test_echr_extraction.py
+++ b/airflow/dags/tests/test_echr_extraction.py
@@ -1,0 +1,54 @@
+import pandas as pd
+from data_extraction.caselaw.echr.echr_extraction import (
+    _canonical_item_ids,
+    _normalize_edge_identifiers,
+)
+
+
+def test_canonical_item_ids_prefer_non_placeholder_variant():
+    metadata = pd.DataFrame(
+        [
+            {
+                "ecli": "ECLI:CE:ECHR:2026:TEST",
+                "itemid": "001-placeholder",
+                "extractedappno": None,
+            },
+            {
+                "ecli": "ECLI:CE:ECHR:2026:TEST",
+                "itemid": "001-real",
+                "extractedappno": "12345/26",
+            },
+        ]
+    )
+
+    assert _canonical_item_ids(metadata) == {"ECLI:CE:ECHR:2026:TEST": "001-real"}
+
+
+def test_normalize_edges_uses_item_ids_for_corpus_documents(tmp_path):
+    metadata = pd.DataFrame(
+        [
+            {
+                "ecli": "ECLI:CE:ECHR:2026:SOURCE",
+                "itemid": "001-source",
+                "extractedappno": "1/26",
+            },
+            {
+                "ecli": "ECLI:CE:ECHR:2025:TARGET",
+                "itemid": "001-target",
+                "extractedappno": "2/25",
+            },
+        ]
+    )
+    path = tmp_path / "ECHR_edges.txt"
+    path.write_text(
+        "ECLI:CE:ECHR:2026:SOURCE,ECLI:CE:ECHR:2025:TARGET\n"
+        "ECLI:CE:ECHR:2026:SOURCE,ECLI:CE:ECHR:2000:EXTERNAL\n",
+        encoding="utf-8",
+    )
+
+    _normalize_edge_identifiers(metadata, str(path))
+
+    assert path.read_text(encoding="utf-8").splitlines() == [
+        "001-source,001-target",
+        "001-source,ECLI:CE:ECHR:2000:EXTERNAL",
+    ]


### PR DESCRIPTION
HUDOC language variants share an ECLI, while cle_v2 stores each item ID separately and keeps cases.ecli unique. Normalize corpus edge endpoints to the real, non-placeholder HUDOC item ID before loading; external ECLI targets remain raw. Existing resolved edge artifacts are normalized on an idempotent rerun, so no extraction or resolution repeat is needed.

Verification: 48 tests passed locally and in the existing Airflow Docker image; Black, compileall, and diff checks passed.