### PR TITLE
Use HUDOC metadata language for full text

### DIFF
--- a/airflow/dags/data_loading/case_text_loader.py
+++ b/airflow/dags/data_loading/case_text_loader.py
@@ -36,9 +36,17 @@ def load_fulltext(client, files_location_paths: list) -> None:
                         f"No case found for ECHR item_id {item_id}, skipping full text"
                     )
                     continue
+                # echr-extractor full-text records commonly omit ``language``.
+                # normalize_language_code(None) falls back to English, which
+                # mislabeled every French body and made the language-keyed
+                # echr_v_document_with_text view look as if it had no text.
+                # The already-loaded metadata row is the source of truth.
+                metadata_language = client.resolve_echr_language_by_item_id(item_id)
                 client.upsert_case_text(
                     case_id=case_id,
-                    language=normalize_language_code(item.get("language")),
+                    language=normalize_language_code(
+                        metadata_language or item.get("language")
+                    ),
                     source="HUDOC",
                     fulltext=item.get("full_text") or item.get("text"),
                 )

--- a/airflow/dags/data_loading/clients/postgres.py
+++ b/airflow/dags/data_loading/clients/postgres.py
@@ -341,6 +341,19 @@ class PostgresCLEClient:
         )
         return row[0] if row else None
 
+    def resolve_echr_language_by_item_id(self, item_id: str) -> str | None:
+        """Return the language stored with the HUDOC metadata document.
+
+        echr-extractor's full-text records do not always repeat the language.
+        The metadata row is authoritative and is also the language used by
+        ``echr_v_document_with_text`` when it joins onto ``case_text``.
+        """
+        row = self.hook.get_first(
+            f"SELECT language FROM {SCHEMA}.echr_document WHERE item_id = %(val)s",
+            parameters={"val": item_id},
+        )
+        return row[0] if row else None
+
     def list_rs_eclis(self) -> list[str]:
         """All Rechtspraak ECLIs known so far, for the citation-refresh DAGs to iterate over."""
         rows = self.hook.get_records(

--- a/airflow/dags/tests/test_case_text_loader.py
+++ b/airflow/dags/tests/test_case_text_loader.py
@@ -8,6 +8,7 @@ from definitions.storage_handler import JSON_FULL_TEXT_CELLAR, JSON_FULL_TEXT_EC
 class RecordingClient:
     def __init__(self):
         self.rows = []
+        self.echr_language = "fr"
 
     def resolve_case_id(self, *, celex_id):
         assert celex_id == "62026CJ0001"
@@ -19,6 +20,10 @@ class RecordingClient:
     def resolve_case_id_by_item_id(self, item_id):
         assert item_id == "001-12345"
         return 43
+
+    def resolve_echr_language_by_item_id(self, item_id):
+        assert item_id == "001-12345"
+        return self.echr_language
 
 
 def test_cellar_fulltexts_keep_each_translation_language(tmp_path):
@@ -105,4 +110,24 @@ def test_hudoc_fulltext_normalizes_three_letter_language(tmp_path):
 
     assert client.rows == [
         {"case_id": 43, "language": "fr", "source": "HUDOC", "fulltext": "Français"}
+    ]
+
+
+def test_hudoc_fulltext_uses_metadata_language_when_blob_omits_it(tmp_path):
+    path = tmp_path / os.path.basename(JSON_FULL_TEXT_ECHR)
+    path.write_text(
+        json.dumps([{"item_id": "001-12345", "full_text": "Texte français"}]),
+        encoding="utf-8",
+    )
+    client = RecordingClient()
+
+    load_fulltext(client, [str(path)])
+
+    assert client.rows == [
+        {
+            "case_id": 43,
+            "language": "fr",
+            "source": "HUDOC",
+            "fulltext": "Texte français",
+        }
     ]

--- a/airflow/dags/tests/test_postgres_client.py
+++ b/airflow/dags/tests/test_postgres_client.py
@@ -146,6 +146,15 @@ def test_has_lido_resolution_passes_the_ecli_as_a_parameter(client, hook):
     assert parameters == {"ecli": "ECLI:NL:HR:2024:3"}
 
 
+def test_resolve_echr_language_by_item_id(client, hook):
+    hook.get_first_return = ("fr",)
+
+    assert client.resolve_echr_language_by_item_id("001-250884") == "fr"
+    sql, parameters = hook.get_first_calls[-1]
+    assert "echr_document" in sql
+    assert parameters == {"val": "001-250884"}
+
+
 def test_nested_transactions_only_commit_at_the_outermost_level(client):
     with client.transaction():
         client.upsert_case(ecli="ECLI:NL:HR:2024:6", source="Rechtspraak")


### PR DESCRIPTION
## Summary

- take HUDOC full-text language from the authoritative `echr_document` metadata row
- fall back to the extractor blob language only when metadata has no language
- add regression coverage for `echr-extractor` blobs that omit language

This fixes French HUDOC bodies being stored under `en`, which made the language-keyed document-with-text view return null even though the body existed.

## Verification

- `pytest -q airflow/dags/tests --ignore=airflow/dags/tests/test_rechtspraak_extraction.py` (50 passed)
- same suite in the existing local Airflow Docker image (50 passed)
- `python -m compileall -q airflow/dags/data_loading`
- `git diff --check`
