### PR TITLE
Pin Airflow to cellar-extractor 2.0.1

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -6,7 +6,7 @@
 # https://raw.githubusercontent.com/apache/airflow/constraints-<version>/constraints-3.11.txt
 
 # caselaw source extractors
-cellar_extractor==2.0.0
+cellar_extractor==2.0.1
 # Pin the timeout and worker-limit fix. HUDOC's conversion endpoint routinely
 # takes longer than the old hard-coded 10s.
 echr_extractor==1.3.2


### PR DESCRIPTION
## Summary
- upgrade the existing Airflow image from `cellar_extractor==2.0.0` to `2.0.1`
- no DAGs added or changed

## Why
2.0.1 includes the post-release multi-work CELEX fix from cellar-extractor PR #11. It unions manifestations across every CELLAR work sharing a CELEX, preventing sparse sibling works from hiding available language versions.

## Verification
- upstream extractor full suite: 138 passed, 53 skipped
- Airflow suite in disposable Docker with the PyPI 2.0.1 wheel: 50 passed
- live disposable-Docker probes recovered bodies for all three previously missing June CELEXes (`62024TJ0662`, `62025TJ0267`, `62025TJ0284`)

Writes remain configured for db-dev only.