### PR TITLE
Pin Airflow to cellar-extractor 2.0.2

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -6,7 +6,7 @@
 # https://raw.githubusercontent.com/apache/airflow/constraints-<version>/constraints-3.11.txt
 
 # caselaw source extractors
-cellar_extractor==2.0.1
+cellar_extractor==2.0.2
 # Pin the timeout and worker-limit fix. HUDOC's conversion endpoint routinely
 # takes longer than the old hard-coded 10s.
 echr_extractor==1.3.2


### PR DESCRIPTION
## Summary
- upgrade the existing Airflow image to `cellar_extractor==2.0.2`
- no DAGs added or changed

## Why
2.0.2 fixes composite metadata identifiers such as `62025TJ0267;62025TJ0267_INF`: multilingual JSON rows now carry canonical CELEX `62025TJ0267`, so the existing loader can attach all translations instead of retaining only the primary English metadata text.

## Verification
- extractor full suite: 139 passed, 53 skipped
- disposable Airflow Docker: exact 2.0.2 wheel, canonical-key regression output, 50 tests passed
- target remains db-dev.