### PR TITLE
Rebuild incomplete Cellar extraction artifacts

### DIFF
--- a/airflow/dags/data_extraction/caselaw/cellar/cellar_extraction.py
+++ b/airflow/dags/data_extraction/caselaw/cellar/cellar_extraction.py
@@ -49,6 +49,18 @@ def _output_paths(output_dir):
     }
 
 
+def _artifacts_complete(paths):
+    """Return true only when the complete monthly extraction is present."""
+    return all(os.path.isfile(path) for path in paths.values())
+
+
+def _write_lines(path, values):
+    """Write a graph artifact, including an empty file for an empty result."""
+    lines = [] if values is False or values is None else values
+    with open(path, "w") as f:
+        f.write("\n".join(lines))
+
+
 def cellar_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
     """
     Run the CELLAR extraction. Writes metadata CSV, full-text JSON, and
@@ -56,9 +68,15 @@ def cellar_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
     continues from the CELEX_LAST_DATE Airflow Variable.
     """
     paths = _output_paths(output_dir)
-    if skip_if_exists and os.path.exists(paths["metadata"]):
-        logging.info(f"{paths['metadata']} exists, skipping extraction.")
+    if skip_if_exists and _artifacts_complete(paths):
+        logging.info("All CELLAR artifacts exist, skipping extraction.")
         return paths
+    if skip_if_exists and any(os.path.exists(path) for path in paths.values()):
+        missing = [name for name, path in paths.items() if not os.path.isfile(path)]
+        logging.warning(
+            "Incomplete CELLAR extraction found; rebuilding it. Missing: %s",
+            ", ".join(missing),
+        )
 
     # Disable SSL verification for this task only: the CELLAR endpoint's
     # certificate chain fails validation from some networks. Runs inside the
@@ -147,15 +165,11 @@ def cellar_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
 
     # Node and edge lists based on citations, for the citation graph
     nodes, edges = cell.get_nodes_and_edges_lists(metadata)
-    if nodes is not False:
-        with open(paths["nodes"], "w") as f:
-            f.write("\n".join(nodes))
-    else:
+    _write_lines(paths["nodes"], nodes)
+    _write_lines(paths["edges"], edges)
+    if nodes is False:
         logging.info("No nodes found")
-    if edges is not False:
-        with open(paths["edges"], "w") as f:
-            f.write("\n".join(edges))
-    else:
+    if edges is False:
         logging.info("No edges found")
 
     end = time.time()

--- a/airflow/dags/tests/test_cellar_extraction.py
+++ b/airflow/dags/tests/test_cellar_extraction.py
@@ -1,0 +1,38 @@
+from data_extraction.caselaw.cellar.cellar_extraction import (
+    _artifacts_complete,
+    _write_lines,
+)
+
+
+def test_artifacts_complete_requires_every_output(tmp_path):
+    paths = {
+        name: str(tmp_path / filename)
+        for name, filename in {
+            "metadata": "cellar.csv",
+            "full_text": "cellar_full_text.json",
+            "nodes": "cellar_nodes.txt",
+            "edges": "cellar_edges.txt",
+        }.items()
+    }
+
+    for path in paths.values():
+        open(path, "w").close()
+
+    assert _artifacts_complete(paths)
+
+    (tmp_path / "cellar_full_text.json").unlink()
+
+    assert not _artifacts_complete(paths)
+
+
+def test_write_lines_materializes_empty_graph_artifacts(tmp_path):
+    nodes_path = tmp_path / "nodes.txt"
+    edges_path = tmp_path / "edges.txt"
+
+    _write_lines(nodes_path, False)
+    _write_lines(edges_path, [])
+
+    assert nodes_path.is_file()
+    assert nodes_path.read_text() == ""
+    assert edges_path.is_file()
+    assert edges_path.read_text() == ""


### PR DESCRIPTION
## What
- only reuse a monthly Cellar extraction when metadata, full text, nodes, and edges all exist
- rebuild partial months instead of silently skipping them
- materialize empty node/edge files for valid citation-free results
- add focused regression tests

## Why
The live staging run found July metadata without cellar_full_text.json; the existing metadata-only skip check treated that partial month as complete.

## Verification
- pytest -q airflow/dags/tests/test_cellar_extraction.py (2 passed)
- full local suite collection is blocked by the workstation lacking rechtspraak_extractor; CI installs project requirements