### PR TITLE
Canonicalize suffix-only Cellar CELEX values

### DIFF
--- a/airflow/dags/data_transformation/utils.py
+++ b/airflow/dags/data_transformation/utils.py
@@ -52,13 +52,15 @@ def format_rs_newline_list(text):
 
 
 def format_cellar_celex(celex):
-    if ";" in celex:
-        separate = celex.split(sep=";")
-        for c in separate:
-            if "_" not in c:
-                return c
-    else:
-        return celex
+    options = [part.strip() for part in str(celex).split(";") if part.strip()]
+    if not options:
+        return None
+    # Prefer a primary document over an information notice. Some valid ECLIs
+    # only expose suffixed documents (for example RES and EXT); those still
+    # belong to the canonical base CELEX used by the loader and full-text rows.
+    non_information = [part for part in options if "INF" not in part]
+    selected = non_information[0] if non_information else options[0]
+    return selected.split("_", 1)[0]
 
 
 # converts string representation of a date into datetime (YYYY-MM-DD)

--- a/airflow/dags/tests/test_data_transformation_utils.py
+++ b/airflow/dags/tests/test_data_transformation_utils.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 from data_transformation.utils import (
+    format_cellar_celex,
     format_echr_date,
     format_jurisdiction,
     format_rs_newline_list,
@@ -37,3 +38,16 @@ def test_format_rs_newline_list_returns_none_for_empty_input():
 
 def test_format_echr_date_uses_documented_day_month_year_order():
     assert format_echr_date("09-07-2026") == date(2026, 7, 9)
+
+
+def test_format_cellar_celex_canonicalizes_suffix_only_documents():
+    assert (
+        format_cellar_celex("62025TJ0204_RES;62025TJ0204_EXT")
+        == "62025TJ0204"
+    )
+
+
+def test_format_cellar_celex_prefers_non_information_document():
+    assert (
+        format_cellar_celex("62025TJ0267_INF;62025TJ0267") == "62025TJ0267"
+    )


### PR DESCRIPTION
## What
- canonicalize multi-document CELEX cells to the base CELEX used by the loader
- handle ECLIs that only expose suffixed RES/EXT documents
- keep preferring non-information documents
- add focused regression tests

## Live case
ECLI:EU:T:2026:377 arrived as 62025TJ0204_RES;62025TJ0204_EXT. The previous transformer returned no key because every option contained an underscore; EUR-Lex confirms the record belongs to CELEX 62025TJ0204_RES (case T-204/25).

## Verification
- pytest -q airflow/dags/tests/test_data_transformation_utils.py airflow/dags/tests/test_cellar_extraction.py (11 passed)