### PR TITLE
Retry ECHR months with incomplete full text

### DIFF
--- a/airflow/dags/data_extraction/caselaw/echr/echr_extraction.py
+++ b/airflow/dags/data_extraction/caselaw/echr/echr_extraction.py
@@ -122,6 +122,35 @@ def _write_citation_artifacts(metadata, paths):
     missing.to_csv(paths["missing_references"], index=False)
 
 
+def _full_text_coverage(metadata, full_text_path):
+    """Return the share of extracted HUDOC item IDs with a non-empty body."""
+    if "itemid" not in metadata.columns or not os.path.isfile(full_text_path):
+        return 0.0
+    item_ids = {
+        str(value).strip()
+        for value in metadata["itemid"].dropna()
+        if str(value).strip()
+    }
+    if not item_ids:
+        return 1.0
+    try:
+        with open(full_text_path, encoding="utf-8") as source:
+            records = json.load(source)
+    except (OSError, json.JSONDecodeError):
+        return 0.0
+    if not isinstance(records, list):
+        return 0.0
+    bodies = {
+        str(record.get("item_id", "")).strip(): (
+            record.get("full_text") or record.get("text") or ""
+        )
+        for record in records
+        if isinstance(record, dict) and record.get("item_id")
+    }
+    available = sum(bool(str(bodies.get(item_id, "")).strip()) for item_id in item_ids)
+    return available / len(item_ids)
+
+
 def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
     """
     Run the ECHR extraction. Writes metadata CSV, full-text JSON, and
@@ -131,15 +160,25 @@ def echr_extract(args, output_dir=None, skip_if_exists: bool = False) -> dict:
     paths = _output_paths(output_dir)
     if skip_if_exists and os.path.exists(paths["metadata"]):
         metadata = pd.read_csv(paths["metadata"])
-        if not all(
-            os.path.exists(paths[name]) for name in ("edges", "missing_references")
-        ):
-            logging.info("Rebuilding missing ECHR citation artifacts from metadata")
-            _write_citation_artifacts(metadata, paths)
-        else:
-            _normalize_edge_identifiers(metadata, paths["edges"])
-        logging.info(f"{paths['metadata']} exists, skipping extraction.")
-        return paths
+        minimum_coverage = float(getenv("ECHR_SKIP_MIN_TEXT_RATIO", "0.90"))
+        coverage = _full_text_coverage(metadata, paths["full_text"])
+        if coverage >= minimum_coverage:
+            if not all(
+                os.path.exists(paths[name])
+                for name in ("edges", "missing_references")
+            ):
+                logging.info("Rebuilding missing ECHR citation artifacts from metadata")
+                _write_citation_artifacts(metadata, paths)
+            else:
+                _normalize_edge_identifiers(metadata, paths["edges"])
+            logging.info(f"{paths['metadata']} exists, skipping extraction.")
+            return paths
+        logging.warning(
+            "Existing ECHR full-text coverage %.3f is below %.3f; "
+            "rebuilding the monthly extraction.",
+            coverage,
+            minimum_coverage,
+        )
 
     # set up script arguments
     parser = argparse.ArgumentParser()

--- a/airflow/dags/tests/test_echr_extraction.py
+++ b/airflow/dags/tests/test_echr_extraction.py
@@ -1,6 +1,9 @@
+import json
+
 import pandas as pd
 from data_extraction.caselaw.echr.echr_extraction import (
     _canonical_item_ids,
+    _full_text_coverage,
     _normalize_edge_identifiers,
 )
 
@@ -52,3 +55,28 @@ def test_normalize_edges_uses_item_ids_for_corpus_documents(tmp_path):
         "001-source,001-target",
         "001-source,ECLI:CE:ECHR:2000:EXTERNAL",
     ]
+
+
+def test_full_text_coverage_counts_only_nonempty_matching_bodies(tmp_path):
+    metadata = pd.DataFrame(
+        [{"itemid": "001-one"}, {"itemid": "001-two"}, {"itemid": "001-three"}]
+    )
+    path = tmp_path / "ECHR_full_text.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"item_id": "001-one", "full_text": "Judgment"},
+                {"item_id": "001-two", "full_text": ""},
+                {"item_id": "unrelated", "full_text": "Other"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert _full_text_coverage(metadata, str(path)) == 1 / 3
+
+
+def test_full_text_coverage_is_zero_for_a_missing_artifact(tmp_path):
+    metadata = pd.DataFrame([{"itemid": "001-one"}])
+
+    assert _full_text_coverage(metadata, str(tmp_path / "missing.json")) == 0.0

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -9,7 +9,7 @@
 cellar_extractor==2.0.2
 # Pin the timeout and worker-limit fix. HUDOC's conversion endpoint routinely
 # takes longer than the old hard-coded 10s.
-echr_extractor==1.3.2
+echr_extractor==1.3.3
 rechtspraak_extractor==1.6.0
 rechtspraak_citations_extractor==1.2.0
 rechtspraak-lido-sqlite==0.2.0


### PR DESCRIPTION
## What
- update the existing ECHR DAG dependency to echr-extractor 1.3.3
- measure item-ID-aligned full-text coverage before reusing a monthly extraction
- rebuild months below 90 percent coverage, while retaining the existing citation-artifact repair path for complete months
- add focused coverage tests

## Why
The live April-August run loaded all 927 HUDOC cases, but only 629 had non-empty bodies. The previous metadata-only skip meant later DAG runs could never retry the 298 empty HUDOC conversion results. echr-extractor 1.3.3 now retries successful-but-empty conversions and preserves an empty record only after the final attempt.

## Verification
- pytest -q airflow/dags/tests/test_echr_extraction.py airflow/dags/tests/test_data_transformation_utils.py airflow/dags/tests/test_cellar_extraction.py (15 passed)
- echr-extractor 1.3.3 is published on PyPI